### PR TITLE
Skip do-nothing lines

### DIFF
--- a/rplugin/python/vim_matlab/python_vim_utils.py
+++ b/rplugin/python/vim_matlab/python_vim_utils.py
@@ -106,6 +106,8 @@ class PythonVimUtils(object):
 
         for line in lines:
             line = PythonVimUtils.comment_pattern.sub(r"\1", line).strip()
+            if line in ('', '...'):
+                continue
 
             has_ellipsis_suffix = ellipsis.match(line)
             if has_ellipsis_suffix:


### PR DESCRIPTION
Skip do-nothing lines instead of appending blank lines. Mainly this permits within-matrix comments as in native MATLAB.

**e.g.:**
```matlab
%%
a = [
  1 2 3;
%  4 5 6;
  7 8 9
]
```

**before:**
```
>> ,a = [,1 2 3;,,7 8 9,],
 EYHUNVJKCQRT=tic;,a = [,1 2 3;,,7 8 9,],,try,toc(EYHUNVJKCQRT),catch,end,clear('EYHUNVJKCQRT');
                                |
Error: Expression or statement is incorrect--possibly unbalanced (, {, or [.
```

**after:**
```
>> ,a = [,1 2 3;,7 8 9,],

a =

     1     2     3
     7     8     9
```