### PR TITLE
Add g:matlab_auto_mappings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ Install and run `:UpdateRemotePlugins`
 Optionally install [SirVer/ultisnips](https://github.com/honza/vim-snippets) to use the snippets.
 
 
+### Configuration
+
+Use this option to prevent the plugin from automatically generating key mappings (default = 1).
+
+```
+let g:matlab_auto_mappings = 0
+```
+
+
 ### Development
 
 Set up a symlink so that the plugin directory points to your repository.

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Run
 
 This will start a Matlab REPL and redirect commands received from Vim to Matlab. When Matlab crashes (e.g. segfault during MEX development), it will launch another process.
 
-Then open Vim in another terminal and start editing .m files
+Then open Vim in another terminal and start editing .m files.
 
-- `:MatlabCliCancel` (\<leader\>C) tells the server to send SIGINT to Matlab, canceling current operation.
+- `:MatlabCliCancel` (\<leader\>c) tells the server to send SIGINT to Matlab, canceling current operation.
 
-- `:MatlabCliRunSelection` executes the highlighted Matlab code
+- `:MatlabCliRunSelection` executes the highlighted Matlab code.
 
 - `:MatlabCliRunCell` executes code in the current cell — i.e. `%%` blocks. Similar to Ctrl-Enter in the Matlab editor.
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ Optionally install [SirVer/ultisnips](https://github.com/honza/vim-snippets) to 
 
 ### Configuration
 
-Use this option to prevent the plugin from automatically generating key mappings (default = 1).
+Use this option to control whether the plugin automatically generates key mappings (default = 1).
 
-```
-let g:matlab_auto_mappings = 0
+``` vim
+let g:matlab_auto_mappings = 0 "automatic mappings disabled
+let g:matlab_auto_mappings = 1 "automatic mappings enabled
 ```
 
 

--- a/ftplugin/matlab/vim-matlab.vim
+++ b/ftplugin/matlab/vim-matlab.vim
@@ -2,20 +2,25 @@ command! MatlabNormalModeCreateCell :execute "normal! :set paste<CR>m`O%%<ESC>``
 command! MatlabVisualModeCreateCell :execute "normal! gvD:set paste<CR>O%%<CR>%%<ESC>P:set nopaste<CR>"
 command! MatlabInsertModeCreateCell :execute "normal! I%% "
 
-nnoremap <buffer>         <leader>rn :MatlabRename
-nnoremap <buffer><silent> <leader>fn :MatlabFixName<CR>
-vnoremap <buffer><silent> <C-m> <ESC>:MatlabCliRunSelection<CR>
-nnoremap <buffer><silent> <C-m> <ESC>:MatlabCliRunCell<CR>
-nnoremap <buffer><silent> ,i <ESC>:MatlabCliViewVarUnderCursor<CR>
-vnoremap <buffer><silent> ,i <ESC>:MatlabCliViewSelectedVar<CR>
-nnoremap <buffer><silent> ,h <ESC>:MatlabCliHelp<CR>
-nnoremap <buffer><silent> ,e <ESC>:MatlabCliOpenInMatlabEditor<CR>
-nnoremap <buffer><silent> <leader>c :MatlabCliCancel<CR>
-nnoremap <buffer><silent> <C-h> :MatlabCliRunLine<CR>
-
 setlocal shortmess+=A
 setlocal formatoptions-=cro
 
-nnoremap <buffer><silent> <C-l> :MatlabNormalModeCreateCell<CR>
-vnoremap <buffer><silent> <C-l> :<C-u>MatlabVisualModeCreateCell<CR>
-inoremap <buffer><silent> <C-l> <C-o>:MatlabInsertModeCreateCell<CR>
+if !exists('g:matlab_auto_mappings')
+  let g:matlab_auto_mappings = 1
+endif
+
+if g:matlab_auto_mappings
+  nnoremap <buffer>         <leader>rn :MatlabRename
+  nnoremap <buffer><silent> <leader>fn :MatlabFixName<CR>
+  vnoremap <buffer><silent> <C-m> <ESC>:MatlabCliRunSelection<CR>
+  nnoremap <buffer><silent> <C-m> <ESC>:MatlabCliRunCell<CR>
+  nnoremap <buffer><silent> <C-h> :MatlabCliRunLine<CR>
+  nnoremap <buffer><silent> ,i <ESC>:MatlabCliViewVarUnderCursor<CR>
+  vnoremap <buffer><silent> ,i <ESC>:MatlabCliViewSelectedVar<CR>
+  nnoremap <buffer><silent> ,h <ESC>:MatlabCliHelp<CR>
+  nnoremap <buffer><silent> ,e <ESC>:MatlabCliOpenInMatlabEditor<CR>
+  nnoremap <buffer><silent> <leader>c :MatlabCliCancel<CR>
+  nnoremap <buffer><silent> <C-l> :MatlabNormalModeCreateCell<CR>
+  vnoremap <buffer><silent> <C-l> :<C-u>MatlabVisualModeCreateCell<CR>
+  inoremap <buffer><silent> <C-l> <C-o>:MatlabInsertModeCreateCell<CR>
+endif


### PR DESCRIPTION
Allows the user to control whether key mappings are automatically generated.