### PR TITLE
Add :MatlabLaunchServer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This will start a Matlab REPL and redirect commands received from Vim to Matlab.
 
 Then open Vim in another terminal and start editing .m files.
 
+Alternatively, launch a server instance from Vim using `:MatlabLaunchServer`. The server will be launched either in a Neovim terminal buffer or a tmux split (see [g:matlab_server_launcher](#configuration)).
+
 - `:MatlabCliCancel` (\<leader\>c) tells the server to send SIGINT to Matlab, canceling current operation.
 
 - `:MatlabCliRunSelection` executes the highlighted Matlab code.
@@ -32,6 +34,8 @@ Then open Vim in another terminal and start editing .m files.
 - `:MatlabVisualModeCreateCell` (C-l) inserts cell markers above and below the visual selection.
 
 - `:MatlabInsertModeCreateCell` (C-l) inserts a cell marker at the beginning of the current line.
+
+- `:MatlabLaunchServer` launches a server instance in a Vim or tmux split.
 
 See [this file](rplugin/python/vim_matlab/__init__.py) for a list of available commands, and [vim-matlab.vim](ftplugin/matlab/vim-matlab.vim) for default key bindings.
 
@@ -58,11 +62,25 @@ Optionally install [SirVer/ultisnips](https://github.com/honza/vim-snippets) to 
 
 ### Configuration
 
-Use this option to control whether the plugin automatically generates key mappings (default = 1).
+Use `g:matlab_auto_mappings` to control whether the plugin automatically generates key mappings (default = 1).
 
-``` vim
+```vim
 let g:matlab_auto_mappings = 0 "automatic mappings disabled
 let g:matlab_auto_mappings = 1 "automatic mappings enabled
+```
+
+Use `g:matlab_server_launcher` to control whether `:MatlabLaunchServer` uses a Vim or tmux split (default = `'vim'`).
+
+```vim
+let g:matlab_server_launcher = 'vim'  "launch the server in a Neovim terminal buffer
+let g:matlab_server_launcher = 'tmux' "launch the server in a tmux split
+```
+
+Use `g:matlab_server_split` to control whether `:MatlabLaunchServer` uses a vertical or horizontal split (default = `'vertical'`).
+
+```vim
+let g:matlab_server_split = 'vertical'   "launch the server in a vertical split
+let g:matlab_server_split = 'horizontal' "launch the server in a horizontal split
 ```
 
 

--- a/ftplugin/matlab/vim-matlab.vim
+++ b/ftplugin/matlab/vim-matlab.vim
@@ -1,9 +1,30 @@
-command! MatlabNormalModeCreateCell :execute "normal! :set paste<CR>m`O%%<ESC>``:set nopaste<CR>"
-command! MatlabVisualModeCreateCell :execute "normal! gvD:set paste<CR>O%%<CR>%%<ESC>P:set nopaste<CR>"
-command! MatlabInsertModeCreateCell :execute "normal! I%% "
-
 setlocal shortmess+=A
 setlocal formatoptions-=cro
+
+if !exists('g:matlab_server_launcher')
+  let g:matlab_server_launcher = 'vim'
+endif
+
+if !exists('g:matlab_server_split')
+  let g:matlab_server_split = 'vertical'
+endif
+
+if g:matlab_server_launcher ==? 'tmux' && g:matlab_server_split ==? 'horizontal'
+  let s:split_command = ':!tmux split-window '
+elseif g:matlab_server_launcher ==? 'tmux' && g:matlab_server_split ==? 'vertical'
+  let s:split_command = ':!tmux split-window -h '
+elseif g:matlab_server_launcher ==? 'vim' && g:matlab_server_split ==? 'horizontal'
+  let s:split_command = ':split term://'
+else
+  let s:split_command = ':vsplit term://'
+endif
+let s:server_command = expand('<sfile>:p:h') . '/../../scripts/vim-matlab-server.py'
+
+command! MatlabLaunchServer :execute 'normal! ' . s:split_command . s:server_command . '<CR>'
+
+command! MatlabNormalModeCreateCell :execute 'normal! :set paste<CR>m`O%%<ESC>``:set nopaste<CR>'
+command! MatlabVisualModeCreateCell :execute 'normal! gvD:set paste<CR>O%%<CR>%%<ESC>P:set nopaste<CR>'
+command! MatlabInsertModeCreateCell :execute 'normal! I%% '
 
 if !exists('g:matlab_auto_mappings')
   let g:matlab_auto_mappings = 1


### PR DESCRIPTION
I usually launch the server in a neovim term split (`:vs term://vim-matlab-server.py`) or a tmux split, so I added a `:MatlabLaunchServer` command for it.

`g:matlab_server_launcher` can be set to `vim` (default) or `tmux`.
`g:matlab_server_split` can be set to `vertical` (default) or `horizontal`.