### PR TITLE
Remove /usr/local from the pkill pattern

### DIFF
--- a/scripts/kill-process.sh
+++ b/scripts/kill-process.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-pkill -f /usr/local/MATLAB; pkill -f vim-matlab-server
+pkill -f /MATLAB; pkill -f vim-matlab-server


### PR DESCRIPTION
My MATLAB executable isn't in /usr/local. I've just removed /usr/local from the path for now.

Not sure what's the most portable solution for this.